### PR TITLE
Update default rtx version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 rtx_download_url: https://ghproxy.com/https://github.com/jdxcode/rtx/releases/download/{{ rtx_version }}/rtx-{{ rtx_version }}-{{ ansible_system }}-x64
-rtx_version: v1.30.4
+rtx_version: v1.34.1
 rtx_user: root
 rtx_group: root
 


### PR DESCRIPTION
pr for rtx 679, 680, 681, 682 merged. this new release support envs. it's better to enable core plugins by setting RTX_EXPERIMENTAL=1